### PR TITLE
Use market://-links when page is opened on an Android device

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 					<a href="#why" class="btn btn-success btn-margin-right btn-lg btn-block btn-margin-bottom cd-next">Why KISS ?</a>
 				</div>
 				<div class="col-md-2">
-					<a target="_blank" href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default btn-beta btn-lg btn-block">Download</a>
+					<a target="_blank" href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default btn-beta btn-lg btn-block link-download">Download</a>
 				</div>				
 			</div>
 		</div>
@@ -70,7 +70,7 @@
 				<div class="col-sm-8">
 					<h2>SMALL</h2>
 					<p>&lt; 150 kb</p>
-					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default" target="_blank">Get it quickly</a>
+					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default link-download" target="_blank">Get it quickly</a>
 				</div>
 			</div>
 		</div>
@@ -85,7 +85,7 @@
 				<div class="col-sm-8">
 					<h2>SAVE</h2>
 					<p>Optimized for battery life</p>
-					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-success" target="_blank">Improve your battery now</a>
+					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-success link-download" target="_blank">Improve your battery now</a>
 				</div>
 			</div>
 		</div>
@@ -100,7 +100,7 @@
 				<div class="col-sm-8">
 					<h2>SMART</h2>
 					<p>Search everything that you need</p>
-					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default" target="_blank">Be smarter</a>
+					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default link-download" target="_blank">Be smarter</a>
 				</div>
 			</div>
 		</div>
@@ -115,7 +115,7 @@
 				<div class="col-sm-8">
 					<h2>FAST</h2>
 					<p>Faster than ever</p>
-					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-success" target="_blank">Be faster</a>
+					<a href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-success link-download" target="_blank">Be faster</a>
 				</div>
 			</div>
 		</div>
@@ -140,7 +140,7 @@
 						KISS Android Launcher helps users find the most used features of their phones to offer an adaptable reception service continuously depending on use patterns.
 					</p>
 					<p class="text-center">
-						<a target="_blank" href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default btn-lg">Just download it</a>
+						<a target="_blank" href="https://play.google.com/store/apps/details?id=fr.neamar.kiss" class="btn btn-default btn-lg link-download">Just download it</a>
 					</p>
 				</div>
 			</div>
@@ -183,6 +183,14 @@
 		</ul> <!-- cd-vertical-nav -->
 	</nav>
 	
+    <script type="text/javascript">
+if(navigator.userAgent.match(/[(;]\s*Android(?:\s+\d+(?:[.]\d+)*)?\s*[;)]/)) {
+	var download_links = document.getElementsByClassName("link-download");
+	for(var i = 0; i < download_links.length; i++) {
+		download_links[i].href = "market://details?id=fr.neamar.kiss";
+	}
+}
+    </script>
 	<script src="js/jquery-2.1.1.js"></script>
 	<script src="js/main.js"></script>
 	<script src="js/kisslauncher.js"></script>


### PR DESCRIPTION
By using market://-links instead of Google Play links on Android devices
the user is able to install the application from any app store available
on his device. This makes sense since the Google Play store is not the
only place where KISS may be installed from.

This change is implemented by adding a piece of JavaScript that runs just
after the page's content has been downloaded and, if the User-Agent
indicates that this is an Android browser, replaces all Google Play links
with their corresponding market://-links
